### PR TITLE
Move development-only dependencies to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
     	}
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.3.0"
+    },
+    "require-dev": {
         "phpdocumentor/phpdocumentor": "2.*",
         "squizlabs/php_codesniffer":"*",
         "phpunit/phpunit":"*",


### PR DESCRIPTION
- Help users of this library avoid dependency conflicts
- Lock file is ignored by users of this library